### PR TITLE
Replace '/project/index/' URI with '/dashboard/index/'.

### DIFF
--- a/src/main/java/org/sonar/plugins/mavenreport/SonarReportMojo.java
+++ b/src/main/java/org/sonar/plugins/mavenreport/SonarReportMojo.java
@@ -142,7 +142,7 @@ public class SonarReportMojo extends AbstractMavenReport {
 
   private String getProjectUrl() {
     StringBuilder sb = new StringBuilder(getSonarUrl())
-        .append("/project/index/")
+        .append("/dashboard/index/")
         .append(project.getGroupId())
         .append(":")
         .append(project.getArtifactId());


### PR DESCRIPTION
Replace _/project/index/_ URI with _/dashboard/index/_ because the first one doesn't work in SonarQube 6.3.1.

**Note**: the last one also tested and works in SonarQube 5.5.

Old invalid link: https://sonarqube.com/project/index/nl.demon.shadowland.freedumbytes.maven:setup
New valid link: https://sonarqube.com/dashboard/index/nl.demon.shadowland.freedumbytes.maven:setup